### PR TITLE
Add optional support for Koa 2

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -2,6 +2,13 @@ module.exports = {
   helpers: {
     raw: function(options) {
       return options.fn(this)
+    },
+    koaSemver: function(answer) {
+      return answer === '1.x' ? '^1.2.5' : '^2.0.0'
+    },
+    ifBabel: function(options) {
+      var needBabel = this.koaVersion === '2.x' && !this.nodeHasAsync
+      return needBabel ? options.fn(this) : ''
     }
   },
   prompts: {
@@ -20,6 +27,19 @@ module.exports = {
       'type': 'string',
       'message': 'Author'
     },
+    koaVersion: {
+      'type': 'list',
+      'required': true,
+      'message': 'Koa version',
+      'choices': ['1.x', '2.x'],
+      'default': 0
+    },
+    nodeHasAsync: {
+      'when': 'koaVersion == "2.x"',
+      'type': 'confirm',
+      'message': 'Are you using node >= v7.6.0?',
+      'default': false
+    }
   },
   completeMessage: '{{#inPlace}}To get started:\n\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'
 };

--- a/template/README.md
+++ b/template/README.md
@@ -6,7 +6,7 @@
 
 ``` bash
 # install dependencies
-$ npm install # Or yarn install
+$ npm install # Or yarn install*[see note below]
 
 # serve with hot reload at localhost:3000
 $ npm run dev
@@ -18,5 +18,10 @@ $ npm start
 # generate static project
 $ npm run generate
 ```
+
+*Note: Due to a bug in yarn's engine version detection code if you are
+using a prerelease version of Node(i.e. v7.6.0-rc.1) you will need to either:
+  1. Use `npm install`
+  2. Run `yarn` with a standard release of Node and then switch back
 
 For detailed explanation on how things work, checkout the [Nuxt.js docs](https://github.com/nuxt/nuxt.js).

--- a/template/app.js
+++ b/template/app.js
@@ -1,4 +1,5 @@
-var app = require('koa')()
+var Koa = require('koa')
+var app = {{#if_eq koaVersion '2.x'}}new {{/if_eq}}Koa()
 var Nuxt = require('nuxt')
 
 var config = require('./nuxt.config.js')
@@ -15,9 +16,17 @@ if (config.dev) {
   })
 }
 
+{{#if_eq koaVersion '1.x'}}
 app.use(function * () {
   this.status = 200 // koa defaults to 404 when it sees that status is unset
   yield nuxt.render(this.req, this.res)
 })
+{{/if_eq}}
+{{#if_eq koaVersion '2.x'}}
+app.use(async (ctx, next) => {
+  ctx.status = 200 // koa defaults to 404 when it sees that status is unset
+  await nuxt.render(ctx.req, ctx.res)
+})
+{{/if_eq}}
 
 app.listen(3000)

--- a/template/package.json
+++ b/template/package.json
@@ -5,17 +5,25 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "nodemon -w app.js -w nuxt.config.js app.js",
-    "build": "nuxt build",
-    "start": "NODE_ENV=production node app.js",
+    "dev": "nodemon -w app.js -w nuxt.config.js{{#ifBabel}} --exec babel-node{{/ifBabel}} app.js",
+    "build": "nuxt build{{#ifBabel}} && babel app.js --out-file app.prod.js{{/ifBabel}}",
+    "start": "NODE_ENV=production node app.{{#ifBabel}}prod.{{/ifBabel}}js",
     "precommit": "npm run lint",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore ."
   },
+  {{#ifBabel}}
+  "babel": {
+    "plugins": "transform-async-to-generator"
+  },
+  {{/ifBabel}}
   "dependencies": {
-    "koa": "latest",
+    "koa": "{{ koaSemver koaVersion }}",
     "nuxt": "latest"
   },
   "devDependencies": {
+    {{#ifBabel}}
+    "babel-cli": "^6.23.0",
+    {{/ifBabel}}
     "babel-eslint": "^7.1.1",
     "eslint": "^3.13.1",
     "eslint-config-standard": "^6.2.1",


### PR DESCRIPTION
Hope you find this useful. I know I should have discussed in an issue before making big changes like this, so if you're not interested in using this feature, that's totally fine. It was worth adding just so I can use it. :)

If you do decide to use it, feel free to make any changes you want, or let me know if you'd like me to change it myself.

### What I did:

I've added a prompt for selecting the desired Koa version(1.x or 2.x). It behaves as follows..

***v1.x chosen*** Everything works exactly as before. I've made this the default answer as well.

***v2.x chosen*** The user is asked if they are using a version of node >= v7.6.0
- ***Yes*** -- They have built-in async/await support so the basic setup for koa@2 is used in app.js and everything else stays the same

- ***No*** -- There will be some more noticeable changes due to lack of async/await support:
  - Add `babel-cli` as a dependency to transpile `app.js`(before webpack runs). `npm run build` will transpile `app.js` to a new file, `app.prod.js`, which `npm start` will use.
  - Use `babel-node` to run `nodemon` so that it can transpile `app.js` on-the-fly
  - Add a `babel` config section to `package.json`. This was just to keep from having to add `--plugins=transform-async-to-generator` in 2 of the scripts since those lines were already pretty long. Also this prevents needing to create a whole new file(`.babelrc`).

Closes #1 