### PR TITLE
Fix lint error(quotes) in nuxt.config.js

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -7,7 +7,7 @@ module.exports = {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', content: "Nuxt.js project" }
+      { hid: 'description', content: 'Nuxt.js project' }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: 'favicon.ico' }


### PR DESCRIPTION
A freshly generated project fails its lint test. This fixes it.